### PR TITLE
Added UseForSiteNavigation

### DIFF
--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2015-09.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2015-09.xsd
@@ -3331,15 +3331,8 @@
               Declares whether the Term Set Item is available for tagging, optional attribute.
             </xsd:documentation>
           </xsd:annotation>
-        </xsd:attribute>
-				<xsd:attribute name="UseForSiteNavigation" type="xsd:boolean" use="optional" default="true">
-					<xsd:annotation>
-						<xsd:documentation xml:lang="en">
-							Allow this term set to be used for Managed Navigation.
-						</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>				
-      </xsd:extension>
+        </xsd:attribute>				
+			</xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>
 
@@ -3387,6 +3380,13 @@
             </xsd:documentation>
           </xsd:annotation>
         </xsd:attribute>
+				<xsd:attribute name="UseForSiteNavigation" type="xsd:boolean" use="optional" default="false">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">
+							Allow this term set to be used for Managed Navigation.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>

--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2015-09.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2015-09.xsd
@@ -1,0 +1,3627 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://schemas.dev.office.com/PnP/2015/08/ProvisioningSchema"
+    elementFormDefault="qualified"
+    xmlns="http://schemas.dev.office.com/PnP/2015/08/ProvisioningSchema"
+    xmlns:pnp="http://schemas.dev.office.com/PnP/2015/08/ProvisioningSchema"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <!-- The main element -->
+  <xsd:element name="Provisioning" type="pnp:Provisioning">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        This is the base element of a Provisioning File.
+      </xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+
+  <!-- The main element for external references -->
+  <xsd:element name="ProvisioningTemplate" type="pnp:ProvisioningTemplate">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        This is the base element of a referenced SharePoint Provisioning Template File.
+      </xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+
+  <xsd:complexType name="Provisioning">
+    <xsd:sequence>
+      <xsd:element name="Preferences" type="pnp:Preferences" minOccurs="1" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            The mandatory section of preferences for the current provisioning definition.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:sequence minOccurs="1" maxOccurs="unbounded">
+        <xsd:element name="Templates" type="pnp:Templates" minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              An optional section made of provisioning templates.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="Sequence" type="pnp:Sequence" minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              An optional section made of provisioning sequences, which can include Sites, Site Collections, Taxonomies, Provisioning Templates, etc.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="ImportSequence" type="pnp:ImportSequence" minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Imports sequences from an external file. All current properties should be sent to that file.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="Preferences" >
+    <xsd:annotation>
+      <xsd:documentation>
+        General settings for a Provisioning file.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Parameters" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            Definition of parameters that can be used as replacement within templates and provisioning objects.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="Parameter" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation>
+                  A Parameter that can be used as a replacement within templates and provisioning objects.
+                </xsd:documentation>
+              </xsd:annotation>
+              <xsd:complexType mixed="true">
+                <xsd:attribute name="Key" use="required" type="xsd:string">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      The name of the Parameter
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="Required" use="optional" type="xsd:boolean" default="false">
+                  <xsd:annotation>
+                    <xsd:documentation>
+                      When set to true then a value must be provided in the XML or provided at runtime.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="Version" type="xsd:string"  use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Provisioning File Version number, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="Author" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Provisioning File Author name, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="Generator" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Name of the tool generating this Provisioning File, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="Templates">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        SharePoint Templates, which can be inline or references to external files.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="ProvisioningTemplateFile" type="pnp:ProvisioningTemplateFile" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Reference to an external template file, which will be based on the current schema but will focus only on the SharePointProvisioningTemplate section.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="ProvisioningTemplateReference" type="pnp:ProvisioningTemplateReference" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Reference to another template by ID.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="ProvisioningTemplate" type="pnp:ProvisioningTemplate" minOccurs="0" />
+    </xsd:sequence>
+    <xsd:attribute name="ID" type="xsd:ID" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          A unique identifier of the Templates collection, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="ProvisioningTemplate">
+
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Represents the root element of the SharePoint Provisioning Template.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:all>
+
+      <xsd:element name="Properties" type="pnp:ProvisioningTemplateProperties" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            A set of custom Properties for the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="SitePolicy" type="pnp:ReplaceableString" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Site Policy of the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="RegionalSettings" type="pnp:RegionalSettings" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Regional Settings of the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="SupportedUILanguages" type="pnp:SupportedUILanguages" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Supported UI Languages for the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="AuditSettings" type="pnp:AuditSettings" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Audit Settings for the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="PropertyBagEntries" type="pnp:PropertyBagEntries" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Property Bag entries of the Provisioning Template, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="Security" type="pnp:Security" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Security configurations of the Provisioning Template, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="SiteFields" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Site Columns of the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:any minOccurs="1" maxOccurs="unbounded"
+                      processContents="lax" namespace="##any" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="ContentTypes" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Content Types of the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="ContentType" type="pnp:ContentType"
+                          minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="Lists" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Lists instances of the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="ListInstance" type="pnp:ListInstance"
+                          minOccurs="1" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="Features" type="pnp:Features" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Features (Site or Web) to activate or deactivate while applying the Provisioning Template, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="CustomActions" type="pnp:CustomActions" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Custom Actions (Site or Web) to provision with the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="Files" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Files to provision into the target Site through the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="File" type="pnp:File"
+                          minOccurs="1" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="Pages" type="pnp:Pages" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Pages to provision into the target Site through the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="TermGroups" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The TermGroups element allows provisioning one or more TermGroups into the target Site, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="TermGroup" type="pnp:TermGroup" minOccurs="1" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation xml:lang="en">
+                  The TermGroup element to provision into the target Site through the Provisioning Template, optional element.
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="ComposedLook" type="pnp:ComposedLook" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The ComposedLook for the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="Workflows" type="pnp:Workflows" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Workflows for the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="SearchSettings" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Search Settings for the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:any minOccurs="0" maxOccurs="1" processContents="skip"  />
+          </xsd:sequence>
+        </xsd:complexType>
+        
+      </xsd:element>
+
+      <xsd:element name="Publishing" type="pnp:Publishing" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Publishing capabilities configuration for the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="AddIns" type="pnp:AddIns" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The SharePoint Add-ins to provision into the target Site through the Provisioning Template, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      
+      <xsd:element name="Providers" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Extensiblity Providers to invoke while applying the Provisioning Template, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="Provider" type="pnp:Provider"
+                          minOccurs="1" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:complexType>
+
+      </xsd:element>
+
+    </xsd:all>
+
+    <xsd:attribute name="ID" type="xsd:ID" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The ID of the Provisioning Template, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Version" type="xsd:decimal" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Version of the Provisioning Template, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="ImagePreviewUrl" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Image Preview Url of the Provisioning Template, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="DisplayName" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Display Name of the Provisioning Template, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Description" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Description of the Provisioning Template, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+
+  </xsd:complexType>
+
+  <xsd:complexType name="ProvisioningTemplateProperties">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        A set of custom Properties for the Provisioning Template.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Property" type="pnp:StringDictionaryItem" minOccurs="1" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            A custom Property for the Provisioning Template, collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>                    
+  
+  <xsd:complexType name="RegionalSettings">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines the Regional Settings for a site.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:attribute name="AdjustHijriDays" type="xsd:int" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The number of days to extend or reduce the current month in Hijri calendars, optinal attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="AlternateCalendarType" type="pnp:CalendarType" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Alternate Calendar type that is used on the server, optinal attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="CalendarType" type="pnp:CalendarType" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Calendar Type that is used on the server, optinal attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Collation" type="xsd:int" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Collation that is used on the site, optinal attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="FirstDayOfWeek" type="pnp:DayOfWeek" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The First Day of the Week used in calendars on the server, optinal attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="FirstWeekOfYear" type="xsd:int" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The First Week of the Year used in calendars on the server, optinal attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="LocaleId" type="xsd:int" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Locale Identifier in use on the server, optinal attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="ShowWeeks" type="xsd:boolean" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines whether to display the week number in day or week views of a calendar, optinal attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Time24" type="xsd:boolean" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines whether to use a 24-hour time format in representing the hours of the day, optinal attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="TimeZone" type="pnp:ReplaceableInt" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Time Zone that is used on the server, optinal attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="WorkDayEndHour" type="pnp:WorkHour" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The the default hour at which the work day ends on the calendar that is in use on the server, optinal attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="WorkDays" type="xsd:int" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The work days of Web site calendars, optinal attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="WorkDayStartHour" type="pnp:WorkHour" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The the default hour at which the work day starts on the calendar that is in use on the server, optinal attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:simpleType name="CalendarType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The Type of Calendar used on a site.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="None" />
+      <xsd:enumeration value="Gregorian" />
+      <xsd:enumeration value="Japan" />
+      <xsd:enumeration value="Taiwan" />
+      <xsd:enumeration value="Korea" />
+      <xsd:enumeration value="Hijri" />
+      <xsd:enumeration value="Thai" />
+      <xsd:enumeration value="Hebrew" />
+      <xsd:enumeration value="Gregorian Middle East French Calendar" />
+      <xsd:enumeration value="Gregorian Arabic Calendar" />
+      <xsd:enumeration value="Gregorian Transliterated English Calendar" />
+      <xsd:enumeration value="Gregorian Transliterated French Calendar" />
+      <xsd:enumeration value="Korea and Japanese Lunar" />
+      <xsd:enumeration value="Chinese Lunar" />
+      <xsd:enumeration value="Saka Era" />
+      <xsd:enumeration value="Umm al-Qura" />
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="DayOfWeek">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The Days of a Week.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="Sunday" />
+      <xsd:enumeration value="Monday" />
+      <xsd:enumeration value="Tuesday" />
+      <xsd:enumeration value="Wednesday" />
+      <xsd:enumeration value="Thursday" />
+      <xsd:enumeration value="Friday" />
+      <xsd:enumeration value="Saturday" />
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="WorkHour">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The Work Hours of a Day.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="12:00AM" />
+      <xsd:enumeration value="1:00AM" />
+      <xsd:enumeration value="2:00AM" />
+      <xsd:enumeration value="3:00AM" />
+      <xsd:enumeration value="4:00AM" />
+      <xsd:enumeration value="5:00AM" />
+      <xsd:enumeration value="6:00AM" />
+      <xsd:enumeration value="7:00AM" />
+      <xsd:enumeration value="8:00AM" />
+      <xsd:enumeration value="9:00AM" />
+      <xsd:enumeration value="10:00AM" />
+      <xsd:enumeration value="11:00AM" />
+      <xsd:enumeration value="12:00PM" />
+      <xsd:enumeration value="1:00PM" />
+      <xsd:enumeration value="2:00PM" />
+      <xsd:enumeration value="3:00PM" />
+      <xsd:enumeration value="4:00PM" />
+      <xsd:enumeration value="5:00PM" />
+      <xsd:enumeration value="6:00PM" />
+      <xsd:enumeration value="7:00PM" />
+      <xsd:enumeration value="8:00PM" />
+      <xsd:enumeration value="9:00PM" />
+      <xsd:enumeration value="10:00PM" />
+      <xsd:enumeration value="11:00PM" />
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:complexType name="SupportedUILanguages">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines the Supported UI Languages for a site.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="SupportedUILanguage" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Defines a single Supported UI Language for a site.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:attribute name="LCID" type="xsd:int" use="required">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The Locale ID of a Supported UI Language, required attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="AuditSettings">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The Audit Settings for the Provisioning Template, optional collection of elements.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="Audit" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            A single Audit setting defined by an AuditFlag.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:attribute name="AuditFlag" use="required">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                An Audit Flag for a single Audit setting, required attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+              <xsd:annotation>
+                <xsd:documentation xml:lang="en">
+                  Type of an Audit Flag for a single Audit setting.
+                </xsd:documentation>
+              </xsd:annotation>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="All" />
+                <xsd:enumeration value="CheckIn" />
+                <xsd:enumeration value="CheckOut" />
+                <xsd:enumeration value="ChildDelete" />
+                <xsd:enumeration value="Copy" />
+                <xsd:enumeration value="Move" />
+                <xsd:enumeration value="None" />
+                <xsd:enumeration value="ObjectDelete" />
+                <xsd:enumeration value="ProfileChange" />
+                <xsd:enumeration value="SchemaChange" />
+                <xsd:enumeration value="Search" />
+                <xsd:enumeration value="SecurityChange" />
+                <xsd:enumeration value="Undelete" />
+                <xsd:enumeration value="Update" />
+                <xsd:enumeration value="View" />
+                <xsd:enumeration value="Workflow" />
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+
+    <xsd:attribute name="AuditLogTrimmingRetention" type="xsd:int" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Audit Log Trimming Retention for Audits, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="TrimAuditLog" type="xsd:boolean" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          A flag to enable Audit Log Trimming, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="PropertyBagEntries">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The Property Bag entries of the Provisioning Template, optional collection of elements.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="PropertyBagEntry" type="pnp:PropertyBagEntry"
+                    minOccurs="1" maxOccurs="unbounded" />
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="Security">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The Security configurations of the Provisioning Template, optional collection of elements.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="AdditionalAdministrators" type="pnp:UsersList" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            List of additional Administrators for the Site, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="AdditionalOwners" type="pnp:UsersList" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            List of additional Owners for the Site, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="AdditionalMembers" type="pnp:UsersList" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            List of additional Members for the Site, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="AdditionalVisitors" type="pnp:UsersList" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            List of additional Visitors for the Site, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="SiteGroups" type="pnp:SiteGroups" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            List of additional Groups for the Site, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="Permissions" minOccurs="0">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="RoleDefinitions" type="pnp:RoleDefinitions" minOccurs="0">
+              <xsd:annotation>
+                <xsd:documentation xml:lang="en">
+                  List of Role Definitions for the Site, optional collection of elements.
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="RoleAssignments" type="pnp:RoleAssignments" minOccurs="0">
+              <xsd:annotation>
+                <xsd:documentation xml:lang="en">
+                  List of Role Assignments for the Site, optional collection of elements.
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="Features">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The Features (Site or Web) to activate or deactivate while applying the Provisioning Template, optional collection of elements.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="SiteFeatures" type="pnp:FeaturesList" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Site Features to activate or deactivate while applying the Provisioning Template, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="WebFeatures" type="pnp:FeaturesList" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Web Features to activate or deactivate while applying the Provisioning Template, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="CustomActions">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The Custom Actions (Site or Web) to provision with the Provisioning Template, optional element.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="SiteCustomActions" type="pnp:CustomActionsList" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Site Custom Actions to provision while applying the Provisioning Template, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="WebCustomActions" type="pnp:CustomActionsList" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Web Custom Actions to provision while applying the Provisioning Template, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="Pages">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The Pages to provision into the target Site through the Provisioning Template, optional collection of elements.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Page" type="pnp:Page"
+                    minOccurs="1" maxOccurs="unbounded" />
+    </xsd:sequence>
+
+    <xsd:attribute name="WelcomePage" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the Welcome Page (Home Page) of the site to which the Provisioning Template is applied, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="PropertyBagEntry" >
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The Property Bag Entry of the Provisioning Template.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="pnp:StringDictionaryItem">
+        <xsd:attribute name="Overwrite" type="xsd:boolean" use="optional">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Declares whether the Property Bag Entry has to overwrite an already existing entry, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="Indexed" type="xsd:boolean" use="optional" default="false">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Declares whether the Property Bag Entry has to be indexed, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="StringDictionaryItem">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a StringDictionary element.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:attribute name="Key" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Key of the property to store in the StringDictionary, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Value" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Value of the property to store in the StringDictionary, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="UsersList">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        List of Users for the Site Security, collection of elements.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="User" type="pnp:User" maxOccurs="unbounded" />
+    </xsd:sequence>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="User">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The base type for a User element.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:attribute name="Name" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Name of the User, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="SiteGroups">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        List of Site Groups for the Site Security, collection of elements.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="SiteGroup" type="pnp:SiteGroup" maxOccurs="unbounded" />
+    </xsd:sequence>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="SiteGroup">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The base type for a Site Group element.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="Members" type="pnp:UsersList" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The list of members of the Site Group, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+
+    <xsd:attribute name="Title" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Title of the Site Group, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Description" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Description of the Site Group, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Owner" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Owner of the Site Group, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="AllowMembersEditMembership" type="xsd:boolean" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines whether the members can edit membership of the Site Group, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="AllowRequestToJoinLeave" type="xsd:boolean" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines whether to allow requests to join or leave the Site Group, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="AutoAcceptRequestToJoinLeave" type="xsd:boolean" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines whether to auto-accept requests to join or leave the Site Group, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="OnlyAllowMembersViewMembership" type="xsd:boolean" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines whether to allow members only to view the membership of the Site Group, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="RequestToJoinLeaveEmailSetting" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the email address used for membership requests to join or leave will be sent for the Site Group, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="RoleDefinitions">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        List of Role Definitions for a target RoleAssignment, collection of elements.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="RoleDefinition" type="pnp:RoleDefinition" maxOccurs="unbounded" />
+    </xsd:sequence>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="RoleDefinition">
+
+    <xsd:sequence>
+      <xsd:element name="Permissions" minOccurs="1" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Defines the Permissions of the Role Definition, required element.
+          </xsd:documentation>
+        </xsd:annotation>
+
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="Permission" minOccurs="1" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation xml:lang="en">
+                  Defines a Permission for a Role Definition.
+                </xsd:documentation>
+              </xsd:annotation>
+              <xsd:simpleType>
+                <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                    Available Permissions for a Permission of a Role Definition.
+                  </xsd:documentation>
+                </xsd:annotation>
+                <xsd:restriction base="xsd:string">
+                  <xsd:enumeration value="EmptyMask" />
+                  <xsd:enumeration value="ViewListItems" />
+                  <xsd:enumeration value="AddListItems" />
+                  <xsd:enumeration value="EditListItems" />
+                  <xsd:enumeration value="DeleteListItems" />
+                  <xsd:enumeration value="ApproveItems" />
+                  <xsd:enumeration value="OpenItems" />
+                  <xsd:enumeration value="ViewVersions" />
+                  <xsd:enumeration value="DeleteVersions" />
+                  <xsd:enumeration value="CancelCheckout" />
+                  <xsd:enumeration value="ManagePersonalViews" />
+                  <xsd:enumeration value="ManageLists" />
+                  <xsd:enumeration value="ViewFormPages" />
+                  <xsd:enumeration value="AnonymousSearchAccessList" />
+                  <xsd:enumeration value="Open" />
+                  <xsd:enumeration value="ViewPages" />
+                  <xsd:enumeration value="AddAndCustomizePages" />
+                  <xsd:enumeration value="ApplyThemeAndBorder" />
+                  <xsd:enumeration value="ApplyStyleSheets" />
+                  <xsd:enumeration value="ViewUsageData" />
+                  <xsd:enumeration value="CreateSSCSite" />
+                  <xsd:enumeration value="ManageSubwebs" />
+                  <xsd:enumeration value="CreateGroups" />
+                  <xsd:enumeration value="ManagePermissions" />
+                  <xsd:enumeration value="BrowseDirectories" />
+                  <xsd:enumeration value="BrowseUserInfo" />
+                  <xsd:enumeration value="AddDelPrivateWebParts" />
+                  <xsd:enumeration value="UpdatePersonalWebParts" />
+                  <xsd:enumeration value="ManageWeb" />
+                  <xsd:enumeration value="AnonymousSearchAccessWebLists" />
+                  <xsd:enumeration value="UseClientIntegration" />
+                  <xsd:enumeration value="UseRemoteAPIs" />
+                  <xsd:enumeration value="ManageAlerts" />
+                  <xsd:enumeration value="CreateAlerts" />
+                  <xsd:enumeration value="EditMyUserInfo" />
+                  <xsd:enumeration value="EnumeratePermissions" />
+                  <xsd:enumeration value="FullMask" />
+                </xsd:restriction>
+              </xsd:simpleType>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+
+      </xsd:element>
+    </xsd:sequence>
+
+    <xsd:attribute name="Name" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the Name of the Role Definition, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Description" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the Description of the Role Definition, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="RoleAssignments">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        List of Role Assignments for a target Principal, collection of elements.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="RoleAssignment" type="pnp:RoleAssignment" maxOccurs="unbounded" />
+    </xsd:sequence>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="RoleAssignment">
+
+    <xsd:attribute name="Principal" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the Role to which the assignment will apply, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="RoleDefinition" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the Role to which the assignment will apply, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="ObjectSecurity">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a set of Role Assignments for specific principals.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="BreakRoleInheritance" minOccurs="1" maxOccurs="1">
+        <xsd:complexType>
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Declares a section of custom permissions, breaking role inheritance from parent.
+            </xsd:documentation>
+          </xsd:annotation>
+
+          <xsd:sequence>
+            <xsd:element name="RoleAssignment" type="pnp:RoleAssignment" maxOccurs="unbounded" />
+          </xsd:sequence>
+        
+          <xsd:attribute name="CopyRoleAssignments" type="xsd:boolean" use="required">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                Defines whether to copy role assignments or not while breaking role inheritance, required attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+
+          <xsd:attribute name="ClearSubscopes" type="xsd:boolean" use="required">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                Defines whether to clear subscopes or not while breaking role inheritance, required attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+
+
+  </xsd:complexType>
+
+  <xsd:complexType name="ListInstance">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a ListInstance element
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:all>
+      <xsd:element name="ContentTypeBindings" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The ContentTypeBindings entries of the List Instance, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="ContentTypeBinding" type="pnp:ContentTypeBinding"
+                         minOccurs="1" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="Views" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Views entries of the List Instance, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:any minOccurs="1" maxOccurs="unbounded"
+                     processContents="lax" namespace="##any" />
+          </xsd:sequence>
+          <xsd:attribute name="RemoveExistingViews" use="optional" default="false" type="xsd:boolean">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                A flag to declare if the existing views of the List Instance have to be removed, before adding the custom views, optional attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="Fields" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Fields entries of the List Instance, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:any minOccurs="1" maxOccurs="unbounded"
+                     processContents="lax" namespace="##any" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="FieldRefs" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The FieldRefs entries of the List Instance, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="FieldRef" type="pnp:ListInstanceFieldRef"
+                         minOccurs="1" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="DataRows" maxOccurs="1" minOccurs="0">
+        
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Defines a collection of rows that will be added to the List Instance, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="DataRow" maxOccurs="unbounded" minOccurs="0">
+              <xsd:complexType>
+                <xsd:sequence>
+                  <xsd:element name="DataValue" maxOccurs="unbounded" minOccurs="1" type="pnp:DataValue">
+                    <xsd:annotation>
+                      <xsd:documentation xml:lang="en">
+                        Defines a single field to provision within a row that will be added to the List Instance, collection of elements (field values).
+                      </xsd:documentation>
+                    </xsd:annotation>
+                  </xsd:element>
+                  <xsd:element name="Security" type="pnp:ObjectSecurity" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                      <xsd:documentation xml:lang="en">
+                        Defines the security rules for the row that will be added to the List Instance, optional element.
+                      </xsd:documentation>
+                    </xsd:annotation>
+                  </xsd:element>
+                </xsd:sequence>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="FieldDefaults" maxOccurs="1" minOccurs="0"> 
+        
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Defines a list of default values for the Fields of the List Instance, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="FieldDefault" maxOccurs="unbounded" minOccurs="1" type="pnp:FieldDefault">
+              <xsd:annotation>
+                <xsd:documentation xml:lang="en">
+                  Defines a default value for a Field of the List Instance.
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="Security" type="pnp:ObjectSecurity" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Defines the Security rules for the List Instance, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:all>
+
+    <xsd:attribute name="Title" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Title of the List Instance, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Description" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Description of the List Instance, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="DocumentTemplate" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The DocumentTemplate of the List Instance, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="OnQuickLaunch" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The OnQuickLaunch flag for the List Instance, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="TemplateType" type="xsd:int" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The TemplateType of the List Instance, required attribute.
+          Values available here: https://msdn.microsoft.com/en-us/library/office/microsoft.sharepoint.client.listtemplatetype.aspx
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Url" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Url of the List Instance, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="EnableVersioning" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The EnableVersioning flag for the List Instance, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="EnableMinorVersions" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The EnableMinorVersions flag for the List Instance, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="EnableModeration" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The EnableModeration flag for the List Instance, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="MinorVersionLimit" type="xsd:int" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The MinorVersionLimit for versions history for the List Instance, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="MaxVersionLimit" type="xsd:int" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The MaxVersionLimit for versions history for the List Instance, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="DraftVersionVisibility" type="xsd:int" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The DraftVersionVisibility for the List Instance, optional attribute. The property will be cast to enum DraftVersionVisibility
+          0 - Reader - 	Any user who can read items,
+          1 - Author - Only users who can edit items,
+          2 - Approver - Only users who can approve items (and the author of the item)
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="RemoveExistingContentTypes" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The RemoveExistingContentTypes flag for the List Instance, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="TemplateFeatureID" type="pnp:GUID" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The TemplateFeatureID for the feature on which the List Instance is based, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="ContentTypesEnabled" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The ContentTypesEnabled flag for the List Instance, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Hidden" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Hidden flag for the List Instance, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="EnableAttachments" type="xsd:boolean" use="optional" default="true">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The EnableAttachments flag for the List Instance, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="EnableFolderCreation" type="xsd:boolean" use="optional" default="true">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The EnableFolderCreation flag for the List Instance, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="BaseFieldValue">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The BaseFieldValue of a single field of a row to insert into a target ListInstance.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="pnp:ReplaceableString">
+        <xsd:attribute name="FieldName" use="required" type="xsd:string"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="DataValue">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The DataValue of a single field of a row to insert into a target ListInstance.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="BaseFieldValue" />
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="FieldDefault">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The FieldDefault of a single field of list or library for target ListInstance.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="BaseFieldValue" />
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="ContentType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a Content Type.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:all>
+      <xsd:element name="FieldRefs" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The FieldRefs entries of the List Instance, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="FieldRef" type="pnp:ContentTypeFieldRef"
+                         minOccurs="1" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="DocumentTemplate" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Specifies the document template for the content type. This is the file which SharePoint Foundation opens as a template when a user requests a new item of this content type.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:attribute name="TargetName" type="xsd:string" use="required">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The value of the Content Type ID, required attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="DocumentSetTemplate" type="pnp:DocumentSetTemplate" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Specifies the properties of the DocumentSet Template if the ContentType defines a DocumentSet.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+    </xsd:all>
+
+    <xsd:attribute name="ID" type="pnp:ContentTypeId" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The value of the Content Type ID, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Name" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Name of the Content Type, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Description" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Description of the Content Type, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Group" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Group of the Content Type, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Hidden" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Optional Boolean. True to define the content type as hidden. If you define a content type as hidden, SharePoint Foundation does not display that content type on the New button in list views.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Sealed" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Optional Boolean. True to prevent changes to this content type. You cannot change the value of this attribute through the user interface, but you can change it in code if you have sufficient rights. You must have site collection administrator rights to unseal a content type.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="ReadOnly" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Optional Boolean. TRUE to specify that the content type cannot be edited without explicitly removing the read-only setting. This can be done either in the user interface or in code.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Overwrite" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Optional Boolean. TRUE to overwrite an existing content type with the same ID.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="NewFormUrl" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Specifies the URL of a custom new form to use for list items that have been assigned the content type, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="EditFormUrl" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Specifies the URL of a custom edit form to use for list items that have been assigned the content type, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="DisplayFormUrl" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Specifies the URL of a custom display form to use for list items that have been assigned the content type, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:anyAttribute processContents="skip"/>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="ContentTypeBinding">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines the binding between a ListInstance and a ContentType.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:attribute name="ContentTypeID" type="pnp:ContentTypeId" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The value of the Content Type ID to bind, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Default" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Declares if the Content Type should be the default Content Type in the list or library, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="DocumentSetTemplate">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a DocumentSet Template for creating multiple DocumentSet instances.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="AllowedContentTypes" minOccurs="0" maxOccurs="1">
+        <xsd:complexType>
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              The list of allowed Content Types for the Document Set, optional element.
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:sequence>
+            <xsd:element name="AllowedContentType" minOccurs="1" maxOccurs="unbounded">
+              <xsd:complexType>
+                <xsd:attribute name="ContentTypeID" type="pnp:ContentTypeId" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      The value of the ContentTypeID to allow for the Document Set, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="DefaultDocuments" minOccurs="0" maxOccurs="1">
+        <xsd:complexType>
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              The list of default Documents for the Document Set, optional element.
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:sequence>
+            <xsd:element name="DefaultDocument" minOccurs="1" maxOccurs="unbounded">
+              <xsd:complexType>
+                <xsd:attribute name="Name" type="xsd:string" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      The name (including the relative path) of the Default Document for a Document Set, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="ContentTypeID" type="pnp:ContentTypeId" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      The value of the ContentTypeID of the Default Document for the Document Set, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="FileSourcePath" type="pnp:ReplaceableString" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      The path of the file to upload as a Default Document for the Document Set, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="SharedFields" minOccurs="0" maxOccurs="1">
+        <xsd:complexType>
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              The list of Shared Fields for the Document Set, optional element.
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:sequence>
+            <xsd:element name="SharedField" type="pnp:DocumentSetFieldRef"
+                         minOccurs="1" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="WelcomePageFields" minOccurs="0" maxOccurs="1">
+        <xsd:complexType>
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              The list of Welcome Page Fields for the Document Set, optional element.
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:sequence>
+            <xsd:element name="WelcomePageField" type="pnp:DocumentSetFieldRef"
+                         minOccurs="1" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+
+    <xsd:attribute name="WelcomePage" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the custom WelcomePage for the Document Set, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    
+  </xsd:complexType>
+
+  <xsd:complexType name="FeaturesList">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a collection of elements of type Feature.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="Feature" type="pnp:Feature"
+                   minOccurs="1" maxOccurs="unbounded" />
+    </xsd:sequence>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="Feature">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a single Site or Web Feature, which will be activated or deactivated while applying the Provisioning Template.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:attribute name="ID" type="pnp:GUID" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The unique ID of the Feature, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Deactivate" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines if the feature has to be deactivated or activated while applying the Provisioning Template, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Description" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Description of the feature, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="FieldRefBase">
+    <xsd:attribute name="ID" type="pnp:GUID" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The value of the field ID to bind, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="FieldRefFull">
+    <xsd:complexContent>
+      <xsd:extension base="pnp:FieldRefBase">
+        <xsd:attributeGroup ref="pnp:FieldRefAttributes" />
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:attributeGroup name="FieldRefAttributes">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Common set of attributes for any FieldRef element.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:attribute name="Name" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The name of the field used in the field reference. This is for reference/readibility only.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Required" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Required flag for the field to bind, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Hidden" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Hidden flag for the field to bind, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:attributeGroup>
+
+  <xsd:complexType name="ListInstanceFieldRef">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines the binding between a ListInstance and a Field.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="pnp:FieldRefFull">
+        <xsd:attribute name="DisplayName" type="xsd:string" use="optional">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              The display name of the field to bind, only applicable to fields that will be added to lists, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="ContentTypeFieldRef">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines the binding between a ContentType and a Field.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="pnp:FieldRefFull" />
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="DocumentSetFieldRef">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines the binding between a Document Set and a Field.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="pnp:FieldRefBase" />
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="CustomActionsList">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a collection of elements of type CustomAction.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="CustomAction" type="pnp:CustomAction"
+                   minOccurs="1" maxOccurs="unbounded" />
+    </xsd:sequence>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="CustomAction">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a Custom Action, which will be provisioned while applying the Provisioning Template.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="CommandUIExtension" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Defines the Custom UI Extension XML, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:any minOccurs="0" maxOccurs="unbounded" processContents="lax" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+
+    <xsd:attribute name="Name" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Name of the CustomAction, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Description" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Description of the CustomAction, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Group" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Group of the CustomAction, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Location" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Location of the CustomAction, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Title" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Title of the CustomAction, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Sequence" type="xsd:int" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Sequence of the CustomAction, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Rights" type="xsd:int" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Rights for the CustomAction, based on values from Microsoft.SharePoint.Client.BasePermissions, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Url" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The URL of the CustomAction, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Enabled" type="xsd:boolean" use="optional" default="true">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Enabled flag for the CustomAction, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="ScriptBlock" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The ScriptBlock of the CustomAction, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="ImageUrl" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The ImageUrl of the CustomAction, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="ScriptSrc" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The ScriptSrc of the CustomAction, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="FileProperties">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        A collection of File Properties.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Property" type="pnp:StringDictionaryItem"
+                    minOccurs="1" maxOccurs="unbounded" />
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="File">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a File element, to describe a file that will be provisioned into the target Site.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:all>
+      <xsd:element name="Properties" type="pnp:FileProperties" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The File Properties, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="WebParts" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The webparts to add to the page, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="WebPart" type="pnp:WebPartPageWebPart"
+                         minOccurs="1" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="Security" type="pnp:ObjectSecurity" minOccurs="0" maxOccurs="1" />
+    </xsd:all>
+
+    <xsd:attribute name="Src" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Src of the File, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Folder" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The TargetFolder of the File, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Overwrite" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Overwrite flag for the File, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="Page">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a Page element, to describe a page that will be provisioned into the target Site. Because of the Layout attribute, the assumption is made that you're referring/creating a WikiPage.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:all>
+      <xsd:element name="WebParts" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The webparts to add to the page, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="WebPart" type="pnp:WikiPageWebPart"
+                         minOccurs="1" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="Security" type="pnp:ObjectSecurity" minOccurs="0" maxOccurs="1" />
+    </xsd:all>
+
+    <xsd:attribute name="Url" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The server relative url of the page, supports tokens, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Overwrite" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          If set, overwrites an existing page in the case of a wikipage, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Layout" type="pnp:WikiPageLayout" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the layout of the wikipage, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="WikiPageWebPart">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a WebPart to be added to a WikiPage.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:all>
+      <xsd:element name="Contents" type="xsd:string" minOccurs="1" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Defines the WebPart XML, required element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:all>
+    <xsd:attribute name="Title" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the title of the WebPart, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="Row" type="xsd:int" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the row to add the WebPart to, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="Column" type="xsd:int" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the column to add the WebPart to, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="WebPartPageWebPart">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a webpart to be added to a WebPart Page.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:all>
+      <xsd:element name="Contents" type="xsd:string" minOccurs="1" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Defines the WebPart XML, required element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:all>
+    <xsd:attribute name="Title" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the title of the WebPart, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="Zone" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the zone of a WebPart Page to add the webpart to, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="Order" type="xsd:int" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the index of the WebPart in the zone, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="ComposedLook">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a ComposedLook element.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:attribute name="Name" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Name of the ComposedLook, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="ColorFile" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The ColorFile of the ComposedLook, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="FontFile" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The FontFile of the ComposedLook, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="BackgroundFile" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The BackgroundFile of the ComposedLook, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="MasterPage" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The MasterPage of the ComposedLook, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="SiteLogo" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The SiteLogo of the ComposedLook, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="AlternateCSS" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The AlternateCSS of the ComposedLook, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="Version" type="xsd:int" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Version of the ComposedLook, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="Workflows">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines the Workflows to provision.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      
+      <xsd:element name="WorkflowDefinitions">
+        <xsd:complexType>
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Defines the Workflows Definitions to provision.
+            </xsd:documentation>
+          </xsd:annotation>
+
+          <xsd:sequence>
+            <xsd:element name="WorkflowDefinition" minOccurs="0" maxOccurs="unbounded">
+              <xsd:complexType>
+                <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                    Defines a Workflow Definition to provision, optional element.
+                  </xsd:documentation>
+                </xsd:annotation>
+
+                <xsd:sequence>
+                  <xsd:element name="Properties" minOccurs="0">
+                    <xsd:complexType>
+                      <xsd:annotation>
+                        <xsd:documentation xml:lang="en">
+                          Defines the Properties of the Workflows to provision, optional collection of elements.
+                        </xsd:documentation>
+                      </xsd:annotation>
+
+                      <xsd:sequence>
+                        <xsd:element name="Property" type="pnp:StringDictionaryItem"
+                                      minOccurs="1" maxOccurs="unbounded">
+                          <xsd:annotation>
+                            <xsd:documentation xml:lang="en">
+                              Defines a Property for the Workflows to provision.
+                            </xsd:documentation>
+                          </xsd:annotation>
+                        </xsd:element>
+                      </xsd:sequence>
+                    </xsd:complexType>
+                  </xsd:element>
+
+                  <xsd:element name="FormField" minOccurs="0">
+                    <xsd:complexType>
+                      <xsd:annotation>
+                        <xsd:documentation xml:lang="en">
+                          Defines the FormField XML of the Workflow to provision, optional element.
+                        </xsd:documentation>
+                      </xsd:annotation>
+
+                      <xsd:sequence>
+                        <xsd:any minOccurs="0" maxOccurs="1" processContents="skip" />
+                      </xsd:sequence>
+                    </xsd:complexType>
+                  </xsd:element>
+
+                </xsd:sequence>
+
+                <xsd:attribute name="Id" type="pnp:GUID" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the ID of the Workflow Definition for the current Subscription, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+                
+                <xsd:attribute name="AssociationUrl" type="xsd:string" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the URL of the Workflow Association page, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="Description" type="xsd:string" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      The Description of the Workflow, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="DisplayName" type="xsd:string" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      The Display Name of the Workflow, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="DraftVersion" type="xsd:string" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the DraftVersion of the Workflow, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="InitiationUrl" type="xsd:string" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the URL of the Workflow Initiation page, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="Published" type="xsd:boolean" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines if the Workflow is Published, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="RequiresAssociationForm" type="xsd:boolean" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines if the Workflow requires the Association Form, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="RequiresInitiationForm" type="xsd:boolean" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines if the Workflow requires the Initiation Form, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="RestrictToScope" type="pnp:ReplaceableString" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the Scope Restriction for the Workflow, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="RestrictToType" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the Type of Scope Restriction for the Workflow, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                  <xsd:simpleType>
+                    <xsd:restriction base="xsd:string">
+                      <xsd:enumeration value="Universal" />
+                      <xsd:enumeration value="List" />
+                      <xsd:enumeration value="Site" />
+                    </xsd:restriction>
+                  </xsd:simpleType>
+                </xsd:attribute>
+
+                <xsd:attribute name="XamlPath" type="xsd:string" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the XAML of the Workflow to provision, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+                
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="WorkflowSubscriptions">
+        <xsd:complexType>
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Defines the Workflows Subscriptions to provision.
+            </xsd:documentation>
+          </xsd:annotation>
+
+          <xsd:sequence>
+            <xsd:element name="WorkflowSubscription" minOccurs="0" maxOccurs="unbounded">
+              <xsd:complexType>
+                <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                    Defines a Workflow Subscription to provision, optional collection of elements.
+                  </xsd:documentation>
+                </xsd:annotation>
+
+                <xsd:sequence>
+                  <xsd:element name="PropertyDefinitions" minOccurs="0">
+                    <xsd:complexType>
+                      <xsd:annotation>
+                        <xsd:documentation xml:lang="en">
+                          Defines the Property Definitions of the Workflows to provision, optional collection of elements.
+                        </xsd:documentation>
+                      </xsd:annotation>
+
+                      <xsd:sequence>
+                        <xsd:element name="PropertyDefinition" type="pnp:StringDictionaryItem"
+                                      minOccurs="1" maxOccurs="unbounded">
+                          <xsd:annotation>
+                            <xsd:documentation xml:lang="en">
+                              Defines the Property Definition of the Workflows to provision.
+                            </xsd:documentation>
+                          </xsd:annotation>
+                        </xsd:element>
+                      </xsd:sequence>
+                    </xsd:complexType>
+                  </xsd:element>
+
+                </xsd:sequence>
+
+                <xsd:attribute name="DefinitionId" type="pnp:GUID" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the ID of the Workflow Definition for the current Subscription, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="ListId" type="pnp:ReplaceableString" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the ID of the target list/library for the current Subscription,
+                      optional attribute and if it is missing, the workflow subscription will
+                      be at Site level, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="Enabled" type="xsd:boolean" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines if the Workflow Definition is enabled for the current Subscription, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="EventSourceId" type="pnp:ReplaceableString" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the ID of the Event Source for the current Subscription, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="WorkflowStartEvent" type="xsd:boolean" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines if the Workflow will start manually, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="ItemAddedEvent" type="xsd:boolean" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines if the Workflow will start on item added, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="ItemUpdatedEvent" type="xsd:boolean" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines if the Workflow will start on item updated, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="ManualStartBypassesActivationLimit" type="xsd:boolean" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines if the Workflow can be manually started bypassing the activation limit, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="Name" type="xsd:string" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the Name of the Workflow Subscription, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="ParentContentTypeId" type="xsd:string" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the Parent ContentType Id of the Workflow Subscription, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+                <xsd:attribute name="StatusFieldName" type="xsd:string" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the Status Field Name of the Workflow Subscription, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="AddIns">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines the SharePoint Add-ins to provision, collection of elements.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="Addin" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+
+          <xsd:attribute name="PackagePath" type="xsd:string" use="required">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                Defines the .app file of the SharePoint Add-in to provision, required attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+
+          <xsd:attribute name="Source" use="required">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                Defines the Source of the SharePoint Add-in to provision, required attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="CorporateCatalog" />
+                <xsd:enumeration value="DeveloperSite" />
+                <xsd:enumeration value="InvalidSource" />
+                <xsd:enumeration value="Marketplace" />
+                <xsd:enumeration value="ObjectModel" />
+                <xsd:enumeration value="RemoteObjectModel" />
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+    
+  </xsd:complexType>
+
+  <xsd:complexType name="Publishing">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines the Publishing configuration to provision.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+
+      <xsd:element name="DesignPackage" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Defines a Design Package to import into the current Publishing site, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+
+        <xsd:complexType>
+
+          <xsd:attribute name="DesignPackagePath" type="xsd:string" use="required">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                Defines the path of the Design Package to import into the current Publishing site, required attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+
+          <xsd:attribute name="MajorVersion" type="xsd:int" use="optional">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The Major Version of the Design Package to import into the current Publishing site, optional attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+
+          <xsd:attribute name="MinorVersion" type="xsd:int" use="optional">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The Minor Version of the Design Package to import into the current Publishing site, optional attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+
+          <xsd:attribute name="PackageGuid" type="pnp:GUID" use="optional">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The ID of the Design Package to import into the current Publishing site, optional attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+
+          <xsd:attribute name="PackageName" type="xsd:string" use="required">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The Name of the Design Package to import into the current Publishing site, required attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+
+        </xsd:complexType>
+        
+      </xsd:element>
+
+      <xsd:element name="AvailableWebTemplates" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Defines the Available Web Templates for the current Publishing site, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="WebTemplate" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation xml:lang="en">
+                  Defines an available Web Template for the current Publishing site.
+                </xsd:documentation>
+              </xsd:annotation>
+              <xsd:complexType>
+                <xsd:attribute name="LanguageCode" type="xsd:int" use="optional">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      The Language Code for the Web Template, optional attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="TemplateName" type="xsd:string" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      The Name of the Web Template, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="PageLayouts" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Defines the Available Page Layouts for the current Publishing site, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+
+        <xsd:complexType>
+        
+          <xsd:sequence>
+            <xsd:element name="PageLayout" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation xml:lang="en">
+                  Defines an available Page Layout for the current Publishing site.
+                </xsd:documentation>
+              </xsd:annotation>
+
+              <xsd:complexType>
+                <xsd:attribute name="Path" type="xsd:string" use="required">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      Defines the path of the Page Layout for the current Publishing site, required attribute.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+              </xsd:complexType>
+
+            </xsd:element>
+          </xsd:sequence>
+
+          <xsd:attribute name="Default" type="xsd:string" use="optional">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                Defines the URL of the Default Page Layout for the current Publishing site, if any. Optional attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+
+        </xsd:complexType>
+      </xsd:element>
+
+    </xsd:sequence>
+
+    <xsd:attribute name="AutoCheckRequirements" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines how an engine should behave if the requirements for provisioning publishing capabilities are not satisfied by the target site, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:string">
+          <xsd:enumeration value="MakeCompliant">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                Instructs the engine to make the target site compliant with the requirements.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:enumeration>
+          <xsd:enumeration value="SkipIfNotCompliant">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                Instructs the engine to skip the Publishing section if the target site is not compliant with the requirements.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:enumeration>
+          <xsd:enumeration value="FailIfNotCompliant">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                Instructs the engine to throw an exception/failure if the target site is not compliant with the requirements.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:enumeration>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:attribute>
+    
+  </xsd:complexType>
+
+  <xsd:complexType name="Provider">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines an Extensibility Provider.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="Configuration" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Defines an optional configuration section for the Extensibility Provider. The configuration section can be any XML.
+          </xsd:documentation>
+        </xsd:annotation>
+
+        <xsd:complexType mixed="true">
+          <xsd:sequence>
+            <xsd:any processContents="lax" namespace="##other" minOccurs="0" />
+          </xsd:sequence>
+        </xsd:complexType>
+
+      </xsd:element>
+    </xsd:sequence>
+
+    <xsd:attribute name="Enabled" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines whether the Extensibility Provider is enabled or not, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="HandlerType" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The type of the handler. It can be a FQN of a .NET type, the URL of a node.js file, or whatever else, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+  </xsd:complexType>
+
+  <xsd:complexType name="ProvisioningTemplateFile">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        An element that references an external file.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="File" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Absolute or relative path to the file, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="ID" type="xsd:ID" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          ID of the referenced template, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="ProvisioningTemplateReference">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        An element that references an external file.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="ID" type="xsd:IDREF" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          ID of the referenced template, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="Sequence" >
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Each Provisioning file is split into a set of Sequence elements.
+        The Sequence element groups the artefacts to be provisioned into groups.
+        The Sequences must be evaluated by the provisioning engine in the order in which they appear.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence maxOccurs="unbounded">
+      <xsd:element name="SiteCollection" type="pnp:SiteCollection" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            A Site Collection to provision through a Sequence, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="Site" type="pnp:Site"  minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            A Site to provision through a Sequence, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="TermStore" type="pnp:TermStore"  minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            A Term Store to provision through a Sequence, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="Extensions" type="pnp:Extensions" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Any Extension to provision through a Sequence, optional element.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <!-- TODO: add more top level items here-->
+    </xsd:sequence>
+    <xsd:attribute name="SequenceType" default="Synchronous" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Instructions to the Provisioning engine on how the Containers within the Sequence can be provisioned.
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:string">
+          <xsd:enumeration value="Synchronous">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The Containers within this Sequence has to be provisioned Synchronous in the order that they appear.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:enumeration>
+          <xsd:enumeration value="Asynchronous">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The Containers within this Sequence can be provisioned Asynchronously.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:enumeration>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:attribute>
+    <xsd:attribute name="ID" type="xsd:ID" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          A unique identifier of the Sequence, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="SiteCollection">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a SiteCollection that will be created into the target tenant/farm.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Templates" type="pnp:Templates" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Templates that can be provisioned together with the Site Collection, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="pnp:SiteCollectionAttributes"/>
+    <xsd:attributeGroup ref="pnp:SiteAttributes"/>
+    <xsd:attribute name="Url" type="pnp:ReplaceableString" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Absolute Url to the site, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="Site">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Defines a Site that will be created into a target Site Collection.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Templates" type="pnp:Templates" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            Templates that can be provisioned together with the Site, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="pnp:SiteAttributes"/>
+    <xsd:attribute name="UseSamePermissionsAsParentSite" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="Url" type="pnp:ReplaceableString" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Relative Url to the site, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:attributeGroup name="SiteCollectionAttributes">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Common set of attributes for any Site Collection
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="StorageMaximumLevel" type="pnp:ReplaceableInt" use="optional">
+      <xsd:annotation>
+        <xsd:documentation>
+          Maximum Storage Level, in Megabytes, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="StorageWarningLevel" type="pnp:ReplaceableInt" use="optional">
+      <xsd:annotation>
+        <xsd:documentation>
+          Warning Storage Level, in Megabytes, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="UserCodeMaximumLevel" type="pnp:ReplaceableInt" use="optional">
+      <xsd:annotation>
+        <xsd:documentation>
+          Maximum Resource usage, in points, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="UserCodeWarningLevel" type="pnp:ReplaceableInt" use="optional">
+      <xsd:annotation>
+        <xsd:documentation>
+          Warning Resource usage, in points, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="PrimarySiteCollectionAdmin" type="pnp:ReplaceableString" use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          ID of the Primary Site Collection Admin, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="SecondarySiteCollectionAdmin" type="pnp:ReplaceableString" use="optional">
+      <xsd:annotation>
+        <xsd:documentation>
+          ID of the Secondary Site Collection Admin, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:attributeGroup>
+
+  <xsd:attributeGroup name="SiteAttributes">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Common set of attributes for any Site.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="Title" type="pnp:ReplaceableString"  use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Title of the site, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="CustomJSUrl" type="pnp:ReplaceableString" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Custom JavaScript URL, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="QuickLaunchEnabled" type="xsd:boolean" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Is the Quick launch enabled, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="AlternateCssUrl" type="pnp:ReplaceableString" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Alternat CSS URL, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="Language" type="pnp:ReplaceableString" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Language of the target Site, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="AllowDesigner" type="xsd:boolean" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines whether SharePoint Designer is allowed or not for the target Site, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="MembersCanShare" type="xsd:boolean" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines whether the Site's members can share or not contents, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="TimeZone" type="pnp:ReplaceableInt" use="optional" >
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Time zone of the site, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:attributeGroup>
+
+  <xsd:complexType name="TermStore" >
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        A TermStore to use for provisioning of TermGroups.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="TermGroup" type="pnp:TermGroup" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The TermGroup element to provision into the target TermStore through, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="Scope" use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          The scope of the term store, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:string">
+          <xsd:enumeration value="Default"/>
+          <xsd:enumeration value="Current"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="TermGroup">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        A TermGroup to use for provisioning of TermSets and Terms.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="TaxonomyItem">
+        <xsd:all>
+          <xsd:element name="TermSets">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                A collection of Term Set elements.
+              </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="TermSet" type="pnp:TermSet" minOccurs="0" maxOccurs="unbounded">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      A Term Set, optional collection of elements.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:element>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:all>
+        <xsd:attribute name="Description" type="xsd:string" use="optional">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              The Description of the TermGroup to use for provisioning of TermSets and Terms, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="SiteCollectionTermGroup" type="xsd:boolean" use="optional">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Declares if the TermGroup is the Site Collection Term Group, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="TaxonomyItem">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Base Type for TermGroup, TermSet and Term.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="Name" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Name of the Taxonomy Item, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="ID" type="pnp:GUID" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The ID of the Taxonomy Item, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="TermSetItem" >
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Base type for TermSets and Terms
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="pnp:TaxonomyItem">
+        <xsd:attribute name="Owner" type="xsd:string" use="optional">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              The Owner of the Term Set Item, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="Description" type="xsd:string" use="optional">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              The Description of the Term Set Item, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="IsAvailableForTagging" type="xsd:boolean" use="optional" default="true">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Declares whether the Term Set Item is available for tagging, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+				<xsd:attribute name="UseForSiteNavigation" type="xsd:boolean" use="optional" default="true">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">
+							Allow this term set to be used for Managed Navigation.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>				
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="TermSet">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        A TermSet to provision.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="pnp:TermSetItem">
+        <xsd:all>
+          <xsd:element name="CustomProperties" type="pnp:TaxonomyItemProperties" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The Custom Properties of the Term Set, optional collection of elements.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:element>
+          <xsd:element name="Terms" minOccurs="0" maxOccurs="1">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="Term" type="pnp:Term" minOccurs="0" maxOccurs="unbounded">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      A child Term of the current Term Set Item, optional collection of elements.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:element>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:all>
+        <xsd:attribute name="Language" type="xsd:int" use="optional">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              The reference Language for the Term Set, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="IsOpenForTermCreation" type="xsd:boolean" use="optional" default="false">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Declares whether the Term Set is open for terms creation or not, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="Term">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        A Term to provision into a TermSet or a hyerarchical Term.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="pnp:TermSetItem">
+        <xsd:all>
+          <xsd:element name="Terms" minOccurs="0" maxOccurs="1">
+            <xsd:complexType>
+              <xsd:choice>
+                <xsd:element name="Term" type="Term"  maxOccurs="unbounded" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                      A child Term of the current Term Set Item, optional collection of elements.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:element>
+              </xsd:choice>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="Labels" minOccurs="0" maxOccurs="1" type="pnp:TermLabels">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The Labels of the current Term, optional element.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:element>
+          <xsd:element name="CustomProperties" type="pnp:TaxonomyItemProperties" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The Custom Properties, optional collection of elements.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:element>
+          <xsd:element name="LocalCustomProperties" type="pnp:TaxonomyItemProperties" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The Term local Custom Properties, optional collection of elements.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:element>
+        </xsd:all>
+        <xsd:attribute name="Language" type="xsd:int" use="optional">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              The reference Language for the Term, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="CustomSortOrder" type="xsd:int" use="optional" default="0">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              The Custom Sort Order for the Term, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="TaxonomyItemProperties">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        A collection of Term Properties.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Property" type="pnp:StringDictionaryItem"
+                    minOccurs="1" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            A Term Property, collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="TermLabels">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        A collection of Term Labels, in order to support multi-language terms.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Label" minOccurs="1" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:attribute name="Language" type="xsd:int" use="required">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The reference Language for the Term Label, required attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Value" type="xsd:string" use="required">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                The Value for the Term Label, required attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="IsDefaultForLanguage" type="xsd:boolean" use="optional" default="false">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                Declares whether the current Label is the default for the specific Language, optional attribute.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="TermSets">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        A collection of TermSets to provision.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="TermSet" type="pnp:TermSet" maxOccurs="unbounded" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            A Term Set, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="Extensions">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Extensions are custom XML elements and instructions that can be extensions of this default schema or vendor or engine specific extensions.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+      <xsd:any processContents="lax" namespace="##other"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="ImportSequence">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Imports sequences from an external file. All current properties should be sent to that file.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="File" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Absolute or relative path to the file, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:simpleType name="GUID">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The description of a Global Unique IDentifier
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="(\{)?[a-fA-F0-9]{8}(-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}(\})?"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name='ReplaceableString' id='ReplaceableString'>
+    <xsd:annotation>
+      <xsd:documentation>
+        A Replaceable string is a string that contains parameters enclosed by curly braces {...}
+        At runtime the provisioning engine replaces those parameters with the parameters specified in Preferences/Parameters
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base='xsd:string'>
+      <xsd:annotation>
+        <xsd:documentation>
+          TODO: this should be replaced with a better regexp to validate Replaceable strings
+          Can be something like "{argument}" or "~argument"
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:pattern value='[\s\S]*'/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name='ReplaceableInt' id='ReplaceableInt'>
+    <xsd:annotation>
+      <xsd:documentation>
+        A Replaceable Int is an integer  that contains parameters enclosed by curly braces {...}
+        At runtime the provisioning engine replaces those parameters with the parameters specified in Preferences/Parameters
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base='xsd:string'>
+      <xsd:annotation>
+        <xsd:documentation>
+          TODO: regexp that validates either an integer or something like this "{lcid}" or something like "~lcid"
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:pattern value='[\s\S]+'/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name='ContentTypeId' id='ContentTypeId'>
+    <xsd:restriction base='xsd:string'>
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          A Content Type ID
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:pattern value='0x[a-zA-Z0-9]+'/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="WikiPageLayout">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The column layout of a wiki page
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="OneColumn" />
+      <xsd:enumeration value="OneColumnSidebar" />
+      <xsd:enumeration value="TwoColumns" />
+      <xsd:enumeration value="TwoColumnsHeader" />
+      <xsd:enumeration value="TwoColumnsHeaderFooter" />
+      <xsd:enumeration value="ThreeColumns" />
+      <xsd:enumeration value="ThreeColumnsHeader" />
+      <xsd:enumeration value="ThreeColumnsHeaderFooter" />
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>


### PR DESCRIPTION
As available within the UI I would like to add UseForSiteNavigation to the schema for a Termset.