### PR TITLE
Add support for Reused Terms and Deprecated Terms

### DIFF
--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2015-08.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2015-08.xsd
@@ -3442,6 +3442,34 @@
             </xsd:documentation>
           </xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="IsReused" type="xsd:boolean" use="optional" default="false">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Declares if this term is reused, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="IsSourceTerm" type="xsd:boolean" use="optional" default="true">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              If the IsReused property is set to false, the current Term is not reused and this property will always be true. If the current Term is reused (IsReused returns true), then this property should be set to true if it is the source Term.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="IsDeprecated" type="xsd:boolean" use="optional" default="false">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Declares if this term is deprecated, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="SourceTermId" type="pnp:GUID" use="optional">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              The ID of the source term if this term is reused, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>


### PR DESCRIPTION
Added optional attributes for terms so that the provisioning framework can import/export reused terms and deprecated terms. See https://github.com/OfficeDev/PnP-Sites-Core/pull/139 for the associated updated to the Provisioning Framework.