### PR TITLE
Fix typo in readme.md re: 201605 schema version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ which will provision SharePoint sites and other elements using this schema.
 
 [Version 201605](OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2016-05.xsd)
 
-In order to reference the schema version 201512 you can use the following syntax:
+In order to reference the schema version 201605 you can use the following syntax:
 
 ```xml
 <pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2016/05/ProvisioningSchema"


### PR DESCRIPTION
Fixed readability issue re: referencing 201605 schema version.  Looks like a copy/paste oversight