### PR TITLE
Updated documentation for BackgroundFile attribute of the ComposedLook element

### DIFF
--- a/ProvisioningSchema-2015-05.md
+++ b/ProvisioningSchema-2015-05.md
@@ -1042,7 +1042,7 @@ Attibute|Type|Description
 Name|xsd:string|The Name of the ComposedLook, required attribute
 ColorFile|xsd:string|The ColorFile of the ComposedLook, required attribute
 FontFile|xsd:string|The FontFile of the ComposedLook, required attribute
-BackgroundFile|xsd:string|The BackgroundFile of the ComposedLook, optional attribute
+BackgroundFile|xsd:string|The BackgroundFile of the ComposedLook, required attribute
 MasterPage|xsd:string|The MasterPage of the ComposedLook, required attribute
 SiteLogo|xsd:string|The SiteLogo of the ComposedLook, optional attribute
 AlternateCSS|xsd:string|The AlternateCSS of the ComposedLook, optional attribute

--- a/ProvisioningSchema-2015-08.md
+++ b/ProvisioningSchema-2015-08.md
@@ -1584,7 +1584,7 @@ Attibute|Type|Description
 Name|xsd:string|The Name of the ComposedLook, required attribute.
 ColorFile|xsd:string|The ColorFile of the ComposedLook, required attribute.
 FontFile|xsd:string|The FontFile of the ComposedLook, required attribute.
-BackgroundFile|xsd:string|The BackgroundFile of the ComposedLook, optional attribute.
+BackgroundFile|xsd:string|The BackgroundFile of the ComposedLook, required attribute.
 MasterPage|xsd:string|The MasterPage of the ComposedLook, required attribute.
 SiteLogo|xsd:string|The SiteLogo of the ComposedLook, optional attribute.
 AlternateCSS|xsd:string|The AlternateCSS of the ComposedLook, optional attribute.

--- a/ProvisioningSchema-2015-12.md
+++ b/ProvisioningSchema-2015-12.md
@@ -1737,7 +1737,7 @@ Attibute|Type|Description
 Name|xsd:string|The Name of the ComposedLook, required attribute.
 ColorFile|xsd:string|The ColorFile of the ComposedLook, required attribute.
 FontFile|xsd:string|The FontFile of the ComposedLook, required attribute.
-BackgroundFile|xsd:string|The BackgroundFile of the ComposedLook, optional attribute.
+BackgroundFile|xsd:string|The BackgroundFile of the ComposedLook, required attribute.
 Version|xsd:int|The Version of the ComposedLook, optional attribute.
 <a name="workflows"></a>
 ###Workflows

--- a/ProvisioningSchema-2016-05.md
+++ b/ProvisioningSchema-2016-05.md
@@ -1955,7 +1955,7 @@ Attibute|Type|Description
 Name|xsd:string|The Name of the ComposedLook, required attribute.
 ColorFile|xsd:string|The ColorFile of the ComposedLook, required attribute.
 FontFile|xsd:string|The FontFile of the ComposedLook, required attribute.
-BackgroundFile|xsd:string|The BackgroundFile of the ComposedLook, optional attribute.
+BackgroundFile|xsd:string|The BackgroundFile of the ComposedLook, required attribute.
 Version|xsd:int|The Version of the ComposedLook, optional attribute.
 <a name="workflows"></a>
 ###Workflows


### PR DESCRIPTION
Updated documentation to _required_ attribute as specified in the schema for BackgroundFile attribute of the ComposedLook element.
Changed in all Markdown files:
ProvisioningSchema-2015-05.md 
ProvisioningSchema-2015-08.md 
ProvisioningSchema-2015-12.md 
ProvisioningSchema-2016-05.md 